### PR TITLE
fixed null toMap return null

### DIFF
--- a/Tea/TeaModelExtensions.cs
+++ b/Tea/TeaModelExtensions.cs
@@ -11,7 +11,7 @@ namespace Tea
         {
             if (model == null)
             {
-                return new Dictionary<string, object>();
+                return null;
             }
             var result = new Dictionary<string, object>();
             Type type = model.GetType();

--- a/TeaUnitTests/TeaModelTest.cs
+++ b/TeaUnitTests/TeaModelTest.cs
@@ -15,7 +15,7 @@ namespace TeaUnitTests
         public void TestToMap()
         {
             TeaModel modelNull = null;
-            Assert.Empty(modelNull.ToMap());
+            Assert.Null(modelNull.ToMap());
 
             TestRegModel model = new TestRegModel();
             model.RequestId = "requestID";


### PR DESCRIPTION
* 修复 `null.ToMap` 返回 `null` 而不是空字典