### PR TITLE
improve httpClient no static

### DIFF
--- a/Tea/TeaCore.cs
+++ b/Tea/TeaCore.cs
@@ -19,7 +19,6 @@ namespace Tea
     {
         private static readonly int bufferLength = 1024;
         private static List<string> bodyMethod = new List<string> { "POST", "PUT", "PATCH" };
-        private static readonly HttpClient httpClient = new HttpClient();
 
         public static string ComposeUrl(TeaRequest request)
         {
@@ -72,11 +71,13 @@ namespace Tea
         public static TeaResponse DoAction(TeaRequest request, Dictionary<string, object> runtimeOptions)
         {
             int timeout;
-
+            var url = ComposeUrl(request);
+            Uri uri = new Uri(url);
             HttpRequestMessage req = GetRequestMessage(request, runtimeOptions, out timeout);
 
             try
             {
+                HttpClient httpClient = HttpClientUtils.GetOrAddHttpClient(request.Protocol,uri.Host, uri.Port, runtimeOptions);
                 HttpResponseMessage response = httpClient.SendAsync(req, new CancellationTokenSource(timeout).Token).Result;
                 return new TeaResponse(response);
             }
@@ -94,11 +95,13 @@ namespace Tea
         public static async Task<TeaResponse> DoActionAsync(TeaRequest request, Dictionary<string, object> runtimeOptions)
         {
             int timeout;
-
+            var url = ComposeUrl(request);
+            Uri uri = new Uri(url);
             HttpRequestMessage req = GetRequestMessage(request, runtimeOptions, out timeout);
 
             try
             {
+                HttpClient httpClient = HttpClientUtils.GetOrAddHttpClient(request.Protocol, uri.Host, uri.Port, runtimeOptions);
                 HttpResponseMessage response = await httpClient.SendAsync(req, new CancellationTokenSource(timeout).Token);
                 return new TeaResponse(response);
             }

--- a/Tea/Utils/HttpClientUtils.cs
+++ b/Tea/Utils/HttpClientUtils.cs
@@ -1,0 +1,78 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Net;
+using System.Net.Http;
+using System.Text;
+
+namespace Tea.Utils
+{
+    public class HttpClientUtils
+    {
+        internal static Dictionary<string, HttpClient> httpClients = new Dictionary<string, HttpClient>();
+
+        internal static HttpClient GetOrAddHttpClient(string protocol,string host, int port, Dictionary<string, object> options)
+        {
+            string key;
+            string proxyUrl = options.Get("httpProxy") != null ? options.Get("httpProxy").ToSafeString() : options.Get("httpsProxy").ToSafeString();
+            
+            if(!string.IsNullOrWhiteSpace(proxyUrl))
+            {
+                Uri uri = new Uri(proxyUrl);
+                key = string.Format("{0}:{1}:{2}", protocol, uri.Host, uri.Port);
+            }
+            else
+            {
+                key = string.Format("{0}:{1}:{2}", protocol, host, port);
+            }
+            HttpClient httpClient = (HttpClient)httpClients.Get(key);
+
+            if(httpClient == null)
+            {
+                httpClient = CreatHttpClient(options);
+                httpClients.Add(key, httpClient);
+            }
+
+            return httpClient;
+        }
+
+        internal static HttpClient CreatHttpClient(Dictionary<string, object> options)
+        {
+            HttpClient httpClient;
+            string proxyUrl = options.Get("httpProxy") != null ? options.Get("httpProxy").ToSafeString() : options.Get("httpsProxy").ToSafeString();
+            bool ignoreSSL = options.Get("ignoreSSL").ToSafeBool(false);
+#if NET45
+            var handler = new WebRequestHandler();
+            if(!string.IsNullOrWhiteSpace(proxyUrl))
+            {
+                handler.Proxy = new WebProxy(new Uri(proxyUrl));
+            }
+            else
+            {
+                handler.UseProxy = false;
+            }
+            if(ignoreSSL)
+            {
+                handler.ServerCertificateValidationCallback = delegate { return true; };
+            }
+            httpClient = new HttpClient(handler);
+#else
+            HttpClientHandler httpClientHandler = new HttpClientHandler();
+            if (!string.IsNullOrWhiteSpace(proxyUrl))
+            {
+                httpClientHandler.Proxy = new WebProxy(new Uri(proxyUrl));
+            }
+            else
+            {
+                httpClientHandler.UseProxy = false;
+            }
+            if (ignoreSSL)
+            {
+                httpClientHandler.ServerCertificateCustomValidationCallback = (message, cert, chain, error) => true;
+            }
+            httpClient = new HttpClient(httpClientHandler);
+#endif
+            return httpClient;
+
+        }
+    }
+}

--- a/Tea/tea.csproj
+++ b/Tea/tea.csproj
@@ -35,6 +35,7 @@
     <Reference Include="System.Xml" />
     <Reference Include="System.Configuration" />
     <Reference Include="System.Net.Http" />
+    <PackageReference Include="Microsoft.Net.Http" Version="2.2.29" />
   </ItemGroup>
 
   <ItemGroup>

--- a/TeaUnitTests/TeaCoreTest.cs
+++ b/TeaUnitTests/TeaCoreTest.cs
@@ -63,23 +63,26 @@ namespace TeaUnitTests
         public void TestDoAction()
         {
             TeaRequest teaRequest = new TeaRequest();
-            teaRequest.Protocol = "https";
+            teaRequest.Protocol = "http";
             teaRequest.Method = "GET";
             teaRequest.Headers = new Dictionary<string, string>();
             teaRequest.Headers["host"] = "www.alibabacloud.com";
             teaRequest.Pathname = "/s/zh";
             teaRequest.Query = new Dictionary<string, string>();
             teaRequest.Query.Add("k", "ecs");
-
-            TeaResponse teaResponse = TeaCore.DoAction(teaRequest);
-            Assert.NotNull(teaResponse);
-
             Dictionary<string, object> runtime = new Dictionary<string, object>();
             runtime.Add("readTimeout", 7000);
             runtime.Add("connectTimeout", 7000);
+            runtime.Add("httpsProxy", "http://www.alibabacloud.com/s/zh?k=ecs");
+            runtime.Add("ignoreSSL", true);
 
-            teaResponse = TeaCore.DoAction(teaRequest, runtime);
+            TeaResponse teaResponse = TeaCore.DoAction(teaRequest, runtime);
             Assert.NotNull(teaResponse);
+
+            teaRequest.Protocol = "https";
+            teaResponse = TeaCore.DoAction(teaRequest);
+            Assert.NotNull(teaResponse);
+
 
             string bodyStr = TeaCore.GetResponseBody(teaResponse);
             Assert.NotNull(bodyStr);
@@ -101,7 +104,10 @@ namespace TeaUnitTests
             Dictionary<string, object> runtime404 = new Dictionary<string, object>();
             runtime404.Add("readTimeout", 7000);
             runtime404.Add("connectTimeout", 7000);
-            Assert.Throws<AggregateException>(() => { TeaCore.DoAction(teaRequest404, runtime); });
+            Assert.Throws<AggregateException>(() => { TeaCore.DoAction(teaRequest404, runtime404); });
+
+            TeaRequest teaRequestProxy = new TeaRequest();
+
 
             TeaRequest requestException = new TeaRequest
             {


### PR DESCRIPTION
* 新增对 `HttpClient` 集合的管理，根据 `protocol`, `host` , `port` 是否一致来复用 `HttpClient` (原为静态单例)