### PR TITLE
fix: ShouldRetry maxAttempts boundary off-by-one

### DIFF
--- a/Darabonba/Core.cs
+++ b/Darabonba/Core.cs
@@ -255,7 +255,7 @@ namespace Darabonba
                             continue;
                         }
 
-                        if (ctx.RetriesAttempted > retryCondition.MaxAttempts)
+                        if (ctx.RetriesAttempted >= retryCondition.MaxAttempts)
                         {
                             return false;
                         }

--- a/DarabonbaUnitTests/CoreTest.cs
+++ b/DarabonbaUnitTests/CoreTest.cs
@@ -349,7 +349,7 @@ namespace DaraUnitTests
                 NoRetryCondition = new List<RetryCondition> { retryCondition3 }
             };
 
-            Assert.True(Core.ShouldRetry(retryOptions, retryPolicyContext));
+            Assert.False(Core.ShouldRetry(retryOptions, retryPolicyContext));
 
             retryPolicyContext = new RetryPolicyContext
             {
@@ -409,7 +409,7 @@ namespace DaraUnitTests
                 }
             };
 
-            Assert.True(Core.ShouldRetry(retryOptions, retryPolicyContext));
+            Assert.False(Core.ShouldRetry(retryOptions, retryPolicyContext));
 
             retryPolicyContext = new RetryPolicyContext
             {
@@ -460,6 +460,37 @@ namespace DaraUnitTests
                 }
             };
             Assert.False(Core.ShouldRetry(retryOptions, retryPolicyContext));
+        }
+
+        [Fact]
+        public void TestShouldRetryMaxAttemptsBoundary()
+        {
+            var retryCondition = new RetryCondition
+            {
+                MaxAttempts = 2,
+                Exception = new List<string> { "AException" }
+            };
+            var retryOptions = new RetryOptions
+            {
+                Retryable = true,
+                RetryCondition = new List<RetryCondition> { retryCondition }
+            };
+            var exception = new AException
+            {
+                Message = "AException",
+                Code = "AExceptionCode"
+            };
+
+            Assert.True(Core.ShouldRetry(retryOptions, new RetryPolicyContext
+            {
+                RetriesAttempted = 1,
+                Exception = exception
+            }));
+            Assert.False(Core.ShouldRetry(retryOptions, new RetryPolicyContext
+            {
+                RetriesAttempted = 2,
+                Exception = exception
+            }));
         }
 
         [Fact]


### PR DESCRIPTION
## Summary
- Change `ShouldRetry` to stop when `RetriesAttempted >= MaxAttempts`, matching TS/Python/PHP/Go.
- Update existing unit tests and add `TestShouldRetryMaxAttemptsBoundary` for the boundary case.