### PR TITLE
fix: match retryCondition.Exception by type name, not Message

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,3 +1,6 @@
+### 2026-07-16 Version 1.0.2
+* fix: match retryCondition.Exception by exception type name, not Message
+
 ### 2025-12-30 Version 1.0.1
 * feat: support do sse action
 

--- a/Darabonba/Core.cs
+++ b/Darabonba/Core.cs
@@ -237,7 +237,8 @@ namespace Darabonba
                 {
                     foreach (var noRetryCondition in noRetryConditions)
                     {
-                        if (DictUtils.Contains(noRetryCondition.Exception, daraException.Message) ||
+                        // Match by exception type name (parity with other langs: ex.name / GetName()), not Message.
+                        if (DictUtils.Contains(noRetryCondition.Exception, daraException.GetType().Name) ||
                             DictUtils.Contains(noRetryCondition.ErrorCode, daraException.Code))
                         {
                             return false;
@@ -248,7 +249,7 @@ namespace Darabonba
                 {
                     foreach (var retryCondition in retryConditions)
                     {
-                        if (!DictUtils.Contains(retryCondition.Exception, daraException.Message) &&
+                        if (!DictUtils.Contains(retryCondition.Exception, daraException.GetType().Name) &&
                             !DictUtils.Contains(retryCondition.ErrorCode, daraException.Code))
                         {
                             continue;
@@ -304,7 +305,8 @@ namespace Darabonba
                     {
                         foreach (var retryCondition in retryConditions)
                         {
-                            if (!DictUtils.Contains(retryCondition.Exception, daraException.Message) && !DictUtils.Contains(retryCondition.ErrorCode, daraException.Code))
+                            // Match by exception type name (parity with other langs: ex.name / GetName()), not Message.
+                            if (!DictUtils.Contains(retryCondition.Exception, daraException.GetType().Name) && !DictUtils.Contains(retryCondition.ErrorCode, daraException.Code))
                             {
                                 continue;
                             }

--- a/Darabonba/Darabonba.csproj
+++ b/Darabonba/Darabonba.csproj
@@ -14,7 +14,7 @@
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <PackageReleaseNotes></PackageReleaseNotes>
     <AssemblyName>Darabonba</AssemblyName>
-    <Version>1.0.1</Version>
+    <Version>1.0.2</Version>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <LangVersion>5</LangVersion>
   </PropertyGroup>

--- a/DarabonbaUnitTests/CoreTest.cs
+++ b/DarabonbaUnitTests/CoreTest.cs
@@ -425,6 +425,44 @@ namespace DaraUnitTests
         }
 
         [Fact]
+        public void TestShouldRetryMatchesExceptionTypeNameNotMessage()
+        {
+            var retryCondition = new RetryCondition
+            {
+                MaxAttempts = 3,
+                Exception = new List<string> { "AException" }
+            };
+            var retryOptions = new RetryOptions
+            {
+                Retryable = true,
+                RetryCondition = new List<RetryCondition> { retryCondition }
+            };
+
+            // Config lists type name; Message is a human-readable string and must not be used for matching.
+            var retryPolicyContext = new RetryPolicyContext
+            {
+                RetriesAttempted = 1,
+                Exception = new AException
+                {
+                    Message = "something went wrong",
+                    Code = "SomeCode"
+                }
+            };
+            Assert.True(Core.ShouldRetry(retryOptions, retryPolicyContext));
+
+            retryPolicyContext = new RetryPolicyContext
+            {
+                RetriesAttempted = 1,
+                Exception = new BException
+                {
+                    Message = "AException",
+                    Code = "OtherCode"
+                }
+            };
+            Assert.False(Core.ShouldRetry(retryOptions, retryPolicyContext));
+        }
+
+        [Fact]
         public void TestGetBackoffTime()
         {
             Dictionary<string, object> dic = new Dictionary<string, object>();
@@ -735,7 +773,8 @@ namespace DaraUnitTests
                 RetryCondition = new List<RetryCondition> { retryCondition },
                 NoRetryCondition = null
             };
-            Assert.Equal(100, Core.GetBackoffDelay(retryOptions, retryPolicyContext));
+            // GetBackoffDelay does not gate on Retryable; type-name match still applies backoff.
+            Assert.Equal(400, Core.GetBackoffDelay(retryOptions, retryPolicyContext));
 
             retryOptions = new RetryOptions
             {
@@ -743,7 +782,18 @@ namespace DaraUnitTests
                 RetryCondition = new List<RetryCondition> { retryCondition },
                 NoRetryCondition = null
             };
-            Assert.Equal(100, Core.GetBackoffDelay(retryOptions, retryPolicyContext));
+            // Match by type name ThrottlingException even when Message is unset / not the type name.
+            Assert.Equal(400, Core.GetBackoffDelay(retryOptions, retryPolicyContext));
+
+            retryPolicyContext = new RetryPolicyContext
+            {
+                RetriesAttempted = 1,
+                Exception = new ThrottlingException
+                {
+                    Message = "Request was throttled"
+                }
+            };
+            Assert.Equal(400, Core.GetBackoffDelay(retryOptions, retryPolicyContext));
 
             retryPolicyContext = new RetryPolicyContext
             {


### PR DESCRIPTION
## Summary
- `ShouldRetry` / `GetBackoffDelay` now match `retryCondition.Exception` against `GetType().Name` (parity with other languages' `ex.name` / `GetName()`), not `Message`.
- Typed exceptions such as `ThrottlingException` hit configured backoff even when `Message` is a human-readable string.
- Unit tests cover name-vs-message matching; package version bumped to 1.0.2.