### PR TITLE
feat: DoSSEActionAsync and ReadAsSSEAsync (netstandard2.1+)

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,3 +1,7 @@
+### 2026-07-20 Version 1.0.3
+* feat: add DoSSEActionAsync and ReadAsSSEAsync (netstandard2.1+)
+* feat: add netstandard2.1 target framework
+
 ### 2026-07-16 Version 1.0.2
 * fix: match retryCondition.Exception by exception type name, not Message
 

--- a/Darabonba/Core.cs
+++ b/Darabonba/Core.cs
@@ -111,6 +111,25 @@ namespace Darabonba
                 throw new WebException("operation is timeout");
             }
         }
+
+        public static async Task<Response> DoSSEActionAsync(Request request, Dictionary<string, object> runtimeOptions)
+        {
+            int timeout;
+            var url = ComposeUrl(request);
+            Uri uri = new Uri(url);
+            HttpRequestMessage req = GetRequestMessage(request, runtimeOptions, out timeout);
+
+            try
+            {
+                HttpClient httpClient = HttpClientUtils.GetOrAddHttpClient(request.Protocol, uri.Host, uri.Port, runtimeOptions);
+                HttpResponseMessage response = await httpClient.SendAsync(req, HttpCompletionOption.ResponseHeadersRead).ConfigureAwait(false);
+                return new Response(response);
+            }
+            catch (TaskCanceledException)
+            {
+                throw new WebException("operation is timeout");
+            }
+        }
         
         public static async Task<Response> DoActionAsync(Request request)
         {

--- a/Darabonba/Darabonba.csproj
+++ b/Darabonba/Darabonba.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net45</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netstandard2.1;net45</TargetFrameworks>
     <RootNamespace>Darabonba</RootNamespace>
     <OutputType>Library</OutputType>
     <Authors>Alibaba Cloud</Authors>
@@ -14,9 +14,14 @@
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <PackageReleaseNotes></PackageReleaseNotes>
     <AssemblyName>Darabonba</AssemblyName>
-    <Version>1.0.2</Version>
+    <Version>1.0.3</Version>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <LangVersion>5</LangVersion>
+  </PropertyGroup>
+
+  <PropertyGroup Condition=" '$(TargetFramework)' == 'netstandard2.1' ">
+    <LangVersion>8.0</LangVersion>
+    <DefineConstants>$(DefineConstants);NETSTANDARD2_1</DefineConstants>
   </PropertyGroup>
 
   <!-- Conditionally obtain references for the .NET Framework 4.5 target -->

--- a/Darabonba/Utils/StreamUtils.cs
+++ b/Darabonba/Utils/StreamUtils.cs
@@ -257,5 +257,36 @@ namespace Darabonba.Utils
                 }
             }
         }
+
+#if NETSTANDARD2_1 || NETCOREAPP3_1_OR_GREATER || NET5_0_OR_GREATER
+        public static async System.Collections.Generic.IAsyncEnumerable<SSEEvent> ReadAsSSEAsync(
+            Stream stream,
+            [System.Runtime.CompilerServices.EnumeratorCancellation] System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        {
+            using (var reader = new StreamReader(stream))
+            {
+                var buffer = new char[4096];
+                var rest = string.Empty;
+                int count;
+
+                while ((count = await reader.ReadAsync(buffer, 0, buffer.Length).ConfigureAwait(false)) > 0)
+                {
+                    cancellationToken.ThrowIfCancellationRequested();
+                    var chunk = new string(buffer, 0, count);
+
+                    var eventResult = TryGetEvents(rest, chunk);
+                    rest = eventResult.Remain;
+
+                    if (eventResult.Events != null && eventResult.Events.Count > 0)
+                    {
+                        foreach (var @event in eventResult.Events)
+                        {
+                            yield return @event;
+                        }
+                    }
+                }
+            }
+        }
+#endif
     }
 }

--- a/Darabonba/Utils/StreamUtils.cs
+++ b/Darabonba/Utils/StreamUtils.cs
@@ -2,8 +2,10 @@ using System;
 using System.IO;
 using System.Text;
 using System.Collections.Generic;
-using Newtonsoft.Json;
+using System.Runtime.CompilerServices;
+using System.Threading;
 using System.Threading.Tasks;
+using Newtonsoft.Json;
 using Darabonba.Models;
 
 namespace Darabonba.Utils
@@ -259,9 +261,9 @@ namespace Darabonba.Utils
         }
 
 #if NETSTANDARD2_1 || NETCOREAPP3_1_OR_GREATER || NET5_0_OR_GREATER
-        public static async System.Collections.Generic.IAsyncEnumerable<SSEEvent> ReadAsSSEAsync(
+        public static async IAsyncEnumerable<SSEEvent> ReadAsSSEAsync(
             Stream stream,
-            [System.Runtime.CompilerServices.EnumeratorCancellation] System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+            [EnumeratorCancellation] CancellationToken cancellationToken = default)
         {
             using (var reader = new StreamReader(stream))
             {

--- a/DarabonbaUnitTests/CoreTest.cs
+++ b/DarabonbaUnitTests/CoreTest.cs
@@ -173,6 +173,19 @@ namespace DaraUnitTests
             response = await Core.DoActionAsync(request, runtime);
             Assert.NotNull(response);
 
+            // DoSSEActionAsync uses ResponseHeadersRead; still returns a Response
+            Request sseRequest = new Request
+            {
+                Protocol = "https",
+                Method = "GET",
+                Headers = new Dictionary<string, string>(),
+                Pathname = "/s/zh"
+            };
+            sseRequest.Headers["host"] = "www.alibabacloud.com";
+            Response sseResponse = await Core.DoSSEActionAsync(sseRequest, runtime);
+            Assert.NotNull(sseResponse);
+            Assert.True(sseResponse.StatusCode > 0);
+
             Request request404 = new Request
             {
                 Protocol = "https",

--- a/DarabonbaUnitTests/DarabonbaUnitTests.csproj
+++ b/DarabonbaUnitTests/DarabonbaUnitTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net45</TargetFrameworks>
+    <TargetFrameworks>net8.0;netcoreapp3.1;net45</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <AssemblyName>DaraUnitTests</AssemblyName>
@@ -18,6 +18,14 @@
     <PackageReference Include="Microsoft.NETCore.TestHost" Version="2.0.8" />
     <PackageReference Include="Moq" Version="4.10.1" />
     <PackageReference Include="Codecov" Version="1.1.1" />
+  </ItemGroup>
+
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net8.0' ">
+    <PackageReference Include="xunit" Version="2.4.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp3.1' ">

--- a/DarabonbaUnitTests/Utils/StreamUtilsTest.cs
+++ b/DarabonbaUnitTests/Utils/StreamUtilsTest.cs
@@ -538,6 +538,41 @@ namespace DaraUnitTests.Utils
             }
         }
 
+#if NETCOREAPP3_1_OR_GREATER || NETSTANDARD2_1 || NET5_0_OR_GREATER
+        [Fact]
+        public async Task Test_ReadAsSSEAsync_FromMemory()
+        {
+            string payload = "id: sse-test\nevent: flow\nretry: 3\ndata: {\"count\": 0}\n\n" +
+                             "id: sse-test\nevent: flow\nretry: 3\ndata: {\"count\": 1}\n\n";
+            using (var stream = new MemoryStream(Encoding.UTF8.GetBytes(payload)))
+            {
+                var events = new List<SSEEvent>();
+                await foreach (var sseEvent in StreamUtils.ReadAsSSEAsync(stream))
+                {
+                    events.Add(sseEvent);
+                }
+                Assert.Equal(2, events.Count);
+                Assert.Equal("{\"count\": 0}", events[0].Data);
+                Assert.Equal("sse-test", events[0].Id);
+                Assert.Equal("flow", events[0].Event);
+                Assert.Equal(3, events[0].Retry);
+                Assert.Equal("{\"count\": 1}", events[1].Data);
+            }
+        }
+
+        [Fact]
+        public void Test_ReadAsSSE_FromMemory()
+        {
+            string payload = "id: sse-test\nevent: flow\nretry: 3\ndata: {\"count\": 0}\n\n";
+            using (var stream = new MemoryStream(Encoding.UTF8.GetBytes(payload)))
+            {
+                var events = new List<SSEEvent>(StreamUtils.ReadAsSSE(stream));
+                Assert.Single(events);
+                Assert.Equal("{\"count\": 0}", events[0].Data);
+            }
+        }
+#endif
+
         [Fact]
         public async Task Test_ReadAsSSE_WithNoSpaces()
         {


### PR DESCRIPTION
## Summary
- Add `DoSSEActionAsync` and `ReadAsSSEAsync` (`IAsyncEnumerable`, netstandard2.1+).
- Expand TargetFrameworks with `netstandard2.1` for async SSE consumers.
- Unit tests cover memory-stream SSE parsing and DoSSEActionAsync smoke path.