### PR TITLE
fix: default null MaxAttempts to 3 in ShouldRetry

### DIFF
--- a/Darabonba/Core.cs
+++ b/Darabonba/Core.cs
@@ -255,7 +255,9 @@ namespace Darabonba
                             continue;
                         }
 
-                        if (ctx.RetriesAttempted >= retryCondition.MaxAttempts)
+                        // Null MaxAttempts must not retry forever: in C#, `n >= null` is false.
+                        int maxAttempts = retryCondition.MaxAttempts ?? DefaultMaxAttempts;
+                        if (ctx.RetriesAttempted >= maxAttempts)
                         {
                             return false;
                         }

--- a/DarabonbaUnitTests/CoreTest.cs
+++ b/DarabonbaUnitTests/CoreTest.cs
@@ -494,6 +494,44 @@ namespace DaraUnitTests
         }
 
         [Fact]
+        public void TestShouldRetryDefaultsMaxAttemptsWhenNull()
+        {
+            // Null MaxAttempts must not retry forever: in C#, n >= null is false.
+            var retryCondition = new RetryCondition
+            {
+                MaxAttempts = null,
+                Exception = new List<string> { "AException" },
+                ErrorCode = new List<string> { "AExceptionCode" }
+            };
+            var retryOptions = new RetryOptions
+            {
+                Retryable = true,
+                RetryCondition = new List<RetryCondition> { retryCondition }
+            };
+            var exception = new AException
+            {
+                Message = "AException",
+                Code = "AExceptionCode"
+            };
+
+            Assert.True(Core.ShouldRetry(retryOptions, new RetryPolicyContext
+            {
+                RetriesAttempted = 1,
+                Exception = exception
+            }));
+            Assert.True(Core.ShouldRetry(retryOptions, new RetryPolicyContext
+            {
+                RetriesAttempted = 2,
+                Exception = exception
+            }));
+            Assert.False(Core.ShouldRetry(retryOptions, new RetryPolicyContext
+            {
+                RetriesAttempted = 3,
+                Exception = exception
+            }));
+        }
+
+        [Fact]
         public void TestGetBackoffTime()
         {
             Dictionary<string, object> dic = new Dictionary<string, object>();


### PR DESCRIPTION
## Summary
- `ShouldRetry` now uses `MaxAttempts ?? 3` so a null MaxAttempts cannot retry forever (`n >= null` is false in C#).
- Unit test covers null MaxAttempts stopping at attempt 3.
- Coverage: local net8 harness — changed lines 259–265 hits > 0 (100% diff on the new default).