### PR TITLE
fix: merge Content headers into Response.Headers

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,4 +1,5 @@
-### 2026-07-20 Version 1.0.3
+### 2026-07-21 Version 1.0.3
+* fix: merge HttpContent headers (e.g. Content-Type) into Response.Headers
 * feat: add DoSSEActionAsync and ReadAsSSEAsync (netstandard2.1+)
 * feat: add netstandard2.1 target framework
 

--- a/Darabonba/Response.cs
+++ b/Darabonba/Response.cs
@@ -1,6 +1,9 @@
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Net.Http;
+
+using Darabonba.Utils;
 
 namespace Darabonba
 {
@@ -37,6 +40,18 @@ namespace Darabonba
                 StatusCode = (int)response.StatusCode;
                 StatusMessage = "";
                 Headers = Core.ConvertHeaders(response.Headers);
+                // Content-Type / Content-Length live on Content.Headers; merge for callers.
+                if (response.Content != null && response.Content.Headers != null)
+                {
+                    foreach (var item in response.Content.Headers)
+                    {
+                        string key = ConverterUtils.StrToLower(item.Key);
+                        if (!Headers.ContainsKey(key) && item.Value != null && item.Value.Any())
+                        {
+                            Headers.Add(key, item.Value.First());
+                        }
+                    }
+                }
                 _responseAsync = response;
             }
         }

--- a/DarabonbaUnitTests/ResponseTest.cs
+++ b/DarabonbaUnitTests/ResponseTest.cs
@@ -32,5 +32,19 @@ namespace DaraUnitTests
             Assert.Empty(response.ToMap(true));
             Assert.NotNull(Response.FromMap(new System.Collections.Generic.Dictionary<string, object>()));
         }
+
+        [Fact]
+        public void TestResponseMergesContentHeaders()
+        {
+            HttpResponseMessage httpResponseMessage = new HttpResponseMessage
+            {
+                StatusCode = HttpStatusCode.BadRequest,
+                Content = new StringContent("<Error/>", Encoding.UTF8, "text/xml")
+            };
+            Response response = new Response(httpResponseMessage);
+            Assert.NotNull(response.Headers);
+            Assert.True(response.Headers.ContainsKey("content-type"));
+            Assert.Contains("text/xml", response.Headers["content-type"]);
+        }
     }
 }


### PR DESCRIPTION
## Summary
- Merge `HttpContent` headers (e.g. Content-Type) into `Response.Headers` so callers can detect XML error bodies.
- Add unit coverage for content-type merge; required for CallAsyncSSEApi XML error path.