### PR TITLE
Bump: release version 1.0.2

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,8 +1,6 @@
-### 2026-07-20 Version 1.0.3
+### 2026-07-23 Version 1.0.2
 * feat: add DoSSEActionAsync and ReadAsSSEAsync (netstandard2.1+)
 * feat: add netstandard2.1 target framework
-
-### 2026-07-16 Version 1.0.2
 * fix: match retryCondition.Exception by exception type name, not Message
 
 ### 2025-12-30 Version 1.0.1

--- a/Darabonba/Darabonba.csproj
+++ b/Darabonba/Darabonba.csproj
@@ -14,7 +14,7 @@
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <PackageReleaseNotes></PackageReleaseNotes>
     <AssemblyName>Darabonba</AssemblyName>
-    <Version>1.0.3</Version>
+    <Version>1.0.2</Version>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <LangVersion>5</LangVersion>
   </PropertyGroup>

--- a/Darabonba/Properties/AssemblyInfo.cs
+++ b/Darabonba/Properties/AssemblyInfo.cs
@@ -30,7 +30,7 @@ using System.Runtime.InteropServices;
 //      Revision
 //
 [assembly: AssemblyVersion("1.0.0.0")]
-[assembly: AssemblyFileVersion("1.0.1.0")]
+[assembly: AssemblyFileVersion("1.0.2.0")]
 
 [assembly: InternalsVisibleTo("DaraUnitTests")]
 


### PR DESCRIPTION
## Summary
- Merge unreleased 1.0.2 / 1.0.3 ChangeLog entries into a single Version 1.0.2 release notes.
- Set package Version and AssemblyFileVersion to 1.0.2 for NuGet publish (1.0.3 was never published).