### PR TITLE
feat: DARA_ASYNC_ENUMERABLES_API for netstandard2.0 SSE

### DIFF
--- a/Darabonba/Darabonba.csproj
+++ b/Darabonba/Darabonba.csproj
@@ -19,10 +19,24 @@
     <LangVersion>5</LangVersion>
   </PropertyGroup>
 
+  <!-- DARA_ASYNC_ENUMERABLES_API gates IAsyncEnumerable APIs (same idea as AWS_ASYNC_ENUMERABLES_API).
+       Enabled on non-.NETFramework TFMs; net45 keeps sync-only SSE. -->
+  <PropertyGroup Condition="$([MSBuild]::GetTargetFrameworkIdentifier('$(TargetFramework)')) != '.NETFramework'">
+    <DefineConstants>$(DefineConstants);DARA_ASYNC_ENUMERABLES_API</DefineConstants>
+  </PropertyGroup>
+
+  <PropertyGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
+    <LangVersion>8.0</LangVersion>
+  </PropertyGroup>
+
   <PropertyGroup Condition=" '$(TargetFramework)' == 'netstandard2.1' ">
     <LangVersion>8.0</LangVersion>
     <DefineConstants>$(DefineConstants);NETSTANDARD2_1</DefineConstants>
   </PropertyGroup>
+
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
+    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="8.0.0" />
+  </ItemGroup>
 
   <!-- Conditionally obtain references for the .NET Framework 4.5 target -->
   <!-- .NET 4.5 references, compilation flags and build options -->

--- a/Darabonba/Utils/StreamUtils.cs
+++ b/Darabonba/Utils/StreamUtils.cs
@@ -260,7 +260,7 @@ namespace Darabonba.Utils
             }
         }
 
-#if NETSTANDARD2_1 || NETCOREAPP3_1_OR_GREATER || NET5_0_OR_GREATER
+#if DARA_ASYNC_ENUMERABLES_API
         public static async IAsyncEnumerable<SSEEvent> ReadAsSSEAsync(
             Stream stream,
             [EnumeratorCancellation] CancellationToken cancellationToken = default)

--- a/DarabonbaUnitTests/DarabonbaUnitTests.csproj
+++ b/DarabonbaUnitTests/DarabonbaUnitTests.csproj
@@ -7,6 +7,10 @@
     <AssemblyName>DaraUnitTests</AssemblyName>
   </PropertyGroup>
 
+  <PropertyGroup Condition="$([MSBuild]::GetTargetFrameworkIdentifier('$(TargetFramework)')) != '.NETFramework'">
+    <DefineConstants>$(DefineConstants);DARA_ASYNC_ENUMERABLES_API</DefineConstants>
+  </PropertyGroup>
+
   <ItemGroup>
     <Compile Remove="**/obj/**" />
     <None Remove="**/obj/**" />

--- a/DarabonbaUnitTests/Utils/StreamUtilsTest.cs
+++ b/DarabonbaUnitTests/Utils/StreamUtilsTest.cs
@@ -538,7 +538,7 @@ namespace DaraUnitTests.Utils
             }
         }
 
-#if NETCOREAPP3_1_OR_GREATER || NETSTANDARD2_1 || NET5_0_OR_GREATER
+#if DARA_ASYNC_ENUMERABLES_API
         [Fact]
         public async Task Test_ReadAsSSEAsync_FromMemory()
         {


### PR DESCRIPTION
## Summary
- Gate `ReadAsSSEAsync` with `DARA_ASYNC_ENUMERABLES_API` (AWS_ASYNC_ENUMERABLES_API-style) on non-.NET Framework TFMs.
- Add `Microsoft.Bcl.AsyncInterfaces` + LangVersion 8 for netstandard2.0; keep net45 sync-only without upgrading product TFMs.